### PR TITLE
Fix bot creation link URL to be generic

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 <h3>
 <a id="warning" class="anchor" href="#warning" aria-hidden="true"><span class="octicon octicon-link"></span></a>Warning</h3>
 		  
-<p>Do not use your User token in the SlackChat client side. Access to a user token can grant a user complete access to your Slack account. We recommend creating a <a href="https://waggleindia.slack.com/services/new/bot" target="_blank">Bot User</a> which has limited access to the Slack account.</p>
+<p>Do not use your User token in the SlackChat client side. Access to a user token can grant a user complete access to your Slack account. We recommend creating a <a href="https://api.slack.com/services/new/bot" target="_blank">Bot User</a> which has limited access to the Slack account.</p>
 		  
 <h3>
 <a id="installation" class="anchor" href="#installation" aria-hidden="true"><span class="octicon octicon-link"></span></a>Installation</h3>


### PR DESCRIPTION
The link URL for creating a bot user is `waggleindia.slack.com/services/new/bot`, which prompts the user to sign in to `waggleindia`’s Slack team. I’ve replaced `waggleindia` with `api`. The new link will forward the user to their team’s relevant bot user creation form.
