### PR TITLE
Change the homepage to arjun-mat for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "slack-chat",
   "version": "1.5.4",
-  "homepage": "http://improvi.github.io/slack-chat",
+  "homepage": "http://arjun-mat.github.io/slack-chat",
   "authors": [
     "Arjun Mathai <arjun@improvi.in>"
   ],


### PR DESCRIPTION
This would solve the broken homepage link for bower.json.